### PR TITLE
Fixing #31: missing lib.rome.core.orm.query.one()

### DIFF
--- a/lib/rome/core/models.py
+++ b/lib/rome/core/models.py
@@ -288,10 +288,13 @@ class Entity(ModelBase, IterableModel, utils.ReloadableRelationMixin):
         return getattr(self, "_associated_objects", [])
 
     def to_dict(self):
-        result = {}
-        for key in self.__dict__:
-            result[key] = self.__dict__[key]
-        return result
+        d = self.__dict__.copy()
+        # NOTE(flaper87): Remove
+        # private state instance
+        # It is not serializable
+        # and causes CircularReference
+        d.pop('_sa_instance_state')
+        return d
 
     def reset_associated_objects(self):
         return setattr(self, "_associated_objects", [])

--- a/lib/rome/core/orm/exc.py
+++ b/lib/rome/core/orm/exc.py
@@ -1,0 +1,33 @@
+# Copyright 2010 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# Copyright 2010-2011 OpenStack Foundation
+# Copyright 2012 Justin Santa Barbara
+# Copyright 2013 IBM Corp.
+# Copyright 2015 Mirantis, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Rome ORM exceptions."""
+
+class InvalidRequestError(Exception):
+    """Rome was asked to do something it can't do."""
+
+class NoResultFound(InvalidRequestError):
+    """A database result was required but none was found."""
+
+
+class MultipleResultsFound(InvalidRequestError):
+    """A single database result was required but more than one were found."""
+
+

--- a/lib/rome/core/orm/query.py
+++ b/lib/rome/core/orm/query.py
@@ -9,10 +9,10 @@ import inspect
 import re
 import logging
 import uuid
+import exc
 
 from lib.rome.core.terms.terms import *
 from sqlalchemy.sql.expression import BinaryExpression, BooleanClauseList
-import lib.rome.driver.database_driver as database_driver
 from lib.rome.core.rows.rows import construct_rows, find_table_name, all_selectables_are_functions
 from sqlalchemy.sql.elements import UnaryExpression
 
@@ -113,6 +113,26 @@ class Query:
             return rows[0]
         else:
             None
+
+    def one_or_none(self):
+        ret = self.all()
+
+        l = len(ret)
+        if l == 1:
+            return ret[0]
+        elif l == 0:
+            return None
+        else:
+            raise exc.MultipleResultsFound("Multiple rows were found for one_or_none()")
+
+    def one(self):
+        try:
+            ret = self.one_or_none()
+        except exc.MultipleResultsFound:
+            raise exc.MultipleResultsFound("Multiple results were found for one()")
+        else:
+            if ret is None:
+                raise exc.NoResultFound("No row was found for one()")
 
     def exists(self):
         return self.first() is not None


### PR DESCRIPTION
Added method one() that returns None or exactly one result.
Raises an error if the query returns more than one result.
This is required by glance.db.discovery.api