### PR TITLE
Changing the master-slave terminology

### DIFF
--- a/lib/rome/core/session/fake_session.py
+++ b/lib/rome/core/session/fake_session.py
@@ -27,8 +27,8 @@ class FakeSession():
 
 
 #
-# def get_session(use_slave=False, **kwargs):
-#     # facade = _create_facade_lazily(use_slave)
+# def get_session(use_subordinate=False, **kwargs):
+#     # facade = _create_facade_lazily(use_subordinate)
 #     # return facade.get_session(**kwargs)
 #
 #     return FakeSession()

--- a/lib/rome/utils/MemoizationDecorator.py
+++ b/lib/rome/utils/MemoizationDecorator.py
@@ -47,7 +47,7 @@ class MemoizationDecorator(object):
                     should_retry = False
                 item["modification_lock"].release()
                 if should_retry:
-                    # memory has been destroyed by a master call, simply abort it and repeat the method.
+                    # memory has been destroyed by a main call, simply abort it and repeat the method.
                     return self.__call__(*args, **kwargs)
                 # Wait for the expected value.
                 result = item["result_queue"].get()
@@ -67,7 +67,7 @@ class MemoizationDecorator(object):
                 self.insertion_lock.release()
 
                 if should_retry:
-                    # memory has been initialised by a quicker concurrent call, simply abort it and become a slave.
+                    # memory has been initialised by a quicker concurrent call, simply abort it and become a subordinate.
                     return self.__call__(*args, **kwargs)
 
                 # compute the expected value and store it in a shared memory.
@@ -85,11 +85,11 @@ class MemoizationDecorator(object):
                 # delete the memory item
                 item = self.memory[call_hash]
 
-                # send to concurrent slave calls.
+                # send to concurrent subordinate calls.
                 for i in range(item["waiting_threads_count"]):
                     item["result_queue"].put(result)
 
-                # Once there are no more slave calls, the item can be destroyed
+                # Once there are no more subordinate calls, the item can be destroyed
                 item["modification_lock"].acquire()
                 self.insertion_lock.acquire()
                 del self.memory[call_hash]

--- a/test/glance/api.py
+++ b/test/glance/api.py
@@ -110,7 +110,7 @@ def get_engine():
 #    return facade.get_session(autocommit=autocommit,
 #                              expire_on_commit=expire_on_commit)
 
-def get_session(use_slave = False, **kwargs):
+def get_session(use_subordinate = False, **kwargs):
     return RomeSession()
 
 def clear_db_env():

--- a/test/glance/test_image_get_all.py
+++ b/test/glance/test_image_get_all.py
@@ -34,7 +34,7 @@ def _drop_protected_attrs(model_class, values):
         if attr in values:
             del values[attr]
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/glance/test_image_update.py
+++ b/test/glance/test_image_update.py
@@ -42,7 +42,7 @@ def _drop_protected_attrs(model_class, values):
         if attr in values:
             del values[attr]
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/features/test_convert_datetime.py
+++ b/test/nova/features/test_convert_datetime.py
@@ -12,7 +12,7 @@ import six
 import datetime
 import pytz
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test__action_get_by_request_id.py
+++ b/test/nova/methods/test__action_get_by_request_id.py
@@ -31,7 +31,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test__instance_data_get_for_user.py
+++ b/test/nova/methods/test__instance_data_get_for_user.py
@@ -36,7 +36,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_aggregate_get_by_metadata_key.py
+++ b/test/nova/methods/test_aggregate_get_by_metadata_key.py
@@ -25,7 +25,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_aggregate_metadata_get_by_metadata_key.py
+++ b/test/nova/methods/test_aggregate_metadata_get_by_metadata_key.py
@@ -27,7 +27,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_block_device_mapping_get_all_by_instance.py
+++ b/test/nova/methods/test_block_device_mapping_get_all_by_instance.py
@@ -32,7 +32,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()
@@ -44,12 +44,12 @@ def model_query(context, *args, **kwargs):
     return RomeQuery(*args, **kwargs)
 
 def _block_device_mapping_get_query(context, session=None,
-        columns_to_join=None, use_slave=False):
+        columns_to_join=None, use_subordinate=False):
     if columns_to_join is None:
         columns_to_join = []
 
     query = model_query(context, models.BlockDeviceMapping,
-                        session=session, use_slave=use_slave)
+                        session=session, use_subordinate=use_subordinate)
 
     for column in columns_to_join:
         query = query.options(joinedload(column))
@@ -58,8 +58,8 @@ def _block_device_mapping_get_query(context, session=None,
 
 
 def block_device_mapping_get_all_by_instance(context, instance_uuid,
-                                             use_slave=False):
-    return _block_device_mapping_get_query(context, use_slave=use_slave).\
+                                             use_subordinate=False):
+    return _block_device_mapping_get_query(context, use_subordinate=use_subordinate).\
                  filter_by(instance_uuid=instance_uuid).\
                  all()
 

--- a/test/nova/methods/test_block_device_mapping_update_or_create.py
+++ b/test/nova/methods/test_block_device_mapping_update_or_create.py
@@ -32,7 +32,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_compute_node_get_all.py
+++ b/test/nova/methods/test_compute_node_get_all.py
@@ -24,7 +24,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_conductor_service_update.py
+++ b/test/nova/methods/test_conductor_service_update.py
@@ -27,7 +27,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()
@@ -39,9 +39,9 @@ def model_query(context, *args, **kwargs):
     return RomeQuery(*args, **kwargs)
 
 def _service_get(context, service_id, with_compute_node=True, session=None,
-                 use_slave=False):
+                 use_subordinate=False):
     query = model_query(context, models.Service, session=session,
-                        use_slave=use_slave).\
+                        use_subordinate=use_subordinate).\
                      filter_by(id=service_id)
 
     # if with_compute_node:

--- a/test/nova/methods/test_ensure_default_secgroup.py
+++ b/test/nova/methods/test_ensure_default_secgroup.py
@@ -8,7 +8,7 @@ from lib.rome.core.session.session import Session as RomeSession
 
 import logging
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_extract_flavor.py
+++ b/test/nova/methods/test_extract_flavor.py
@@ -22,7 +22,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_fixed_ip_associate_pool.py
+++ b/test/nova/methods/test_fixed_ip_associate_pool.py
@@ -32,7 +32,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_fixed_ip_from_db_object.py
+++ b/test/nova/methods/test_fixed_ip_from_db_object.py
@@ -34,7 +34,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_fixed_ip_get_by_host.py
+++ b/test/nova/methods/test_fixed_ip_get_by_host.py
@@ -32,7 +32,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_fixed_ip_get_by_instance.py
+++ b/test/nova/methods/test_fixed_ip_get_by_instance.py
@@ -32,7 +32,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_fixed_ip_get_by_instance_uuid.py
+++ b/test/nova/methods/test_fixed_ip_get_by_instance_uuid.py
@@ -35,7 +35,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_fixed_ip_get_by_network.py
+++ b/test/nova/methods/test_fixed_ip_get_by_network.py
@@ -38,7 +38,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_flavor_get_all.py
+++ b/test/nova/methods/test_flavor_get_all.py
@@ -31,7 +31,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_flavor_get_by_flavor_id.py
+++ b/test/nova/methods/test_flavor_get_by_flavor_id.py
@@ -31,7 +31,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_get_by_network.py
+++ b/test/nova/methods/test_get_by_network.py
@@ -34,7 +34,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_instance_create.py
+++ b/test/nova/methods/test_instance_create.py
@@ -28,7 +28,7 @@ INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_instance_faults_get_by_instance_uuids.py
+++ b/test/nova/methods/test_instance_faults_get_by_instance_uuids.py
@@ -28,7 +28,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_instance_get_active_by_window_joined.py
+++ b/test/nova/methods/test_instance_get_active_by_window_joined.py
@@ -36,7 +36,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()
@@ -53,14 +53,14 @@ def _network_get_query(context, session=None):
                        read_deleted="no")
 
 def _instance_get_all_query(context, project_only=False,
-                            joins=None, use_slave=False):
+                            joins=None, use_subordinate=False):
     if joins is None:
         joins = ['info_cache', 'security_groups']
 
     query = model_query(context,
                         models.Instance,
                         project_only=project_only,
-                        use_slave=use_slave)
+                        use_subordinate=use_subordinate)
     # for join in joins:
     #     query = query.options(joinedload(join))
     return query
@@ -71,7 +71,7 @@ def _instance_pcidevs_get_multi(context, instance_uuids, session=None):
         filter(models.PciDevice.instance_uuid.in_(instance_uuids))
 
 def _instances_fill_metadata(context, instances,
-                             manual_joins=None, use_slave=False):
+                             manual_joins=None, use_subordinate=False):
     """Selectively fill instances with manually-joined metadata. Note that
     instance will be converted to a dict.
     :param context: security context
@@ -128,9 +128,9 @@ def _manual_join_columns(columns_to_join):
 
 def instance_get_active_by_window_joined(context, begin, end=None,
                                          project_id=None, host=None,
-                                         use_slave=False):
+                                         use_subordinate=False):
     """Return instances and joins that were active during window."""
-    session = get_session(use_slave=use_slave)
+    session = get_session(use_subordinate=use_subordinate)
     query = session.query(models.Instance)
 
     query = query.options(joinedload('info_cache')).\

--- a/test/nova/methods/test_instance_get_all.py
+++ b/test/nova/methods/test_instance_get_all.py
@@ -32,7 +32,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()
@@ -55,7 +55,7 @@ def _manual_join_columns(columns_to_join):
 
 def instance_get_all_by_filters(context, filters, sort_key, sort_dir,
                                 limit=None, marker=None, columns_to_join=None,
-                                use_slave=False):
+                                use_subordinate=False):
     """Return instances that match all filters.  Deleted instances
     will be returned by default, unless there's a filter that says
     otherwise.
@@ -89,10 +89,10 @@ def instance_get_all_by_filters(context, filters, sort_key, sort_dir,
 
     sort_fn = {'desc': desc, 'asc': asc}
 
-    # if CONF.database.slave_connection == '':
-    #     use_slave = False
+    # if CONF.database.subordinate_connection == '':
+    #     use_subordinate = False
 
-    session = get_session(use_slave=use_slave)
+    session = get_session(use_subordinate=use_subordinate)
 
     if columns_to_join is None:
         columns_to_join = ['info_cache', 'security_groups']

--- a/test/nova/methods/test_instance_get_all_by_filters.py
+++ b/test/nova/methods/test_instance_get_all_by_filters.py
@@ -35,7 +35,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()
@@ -52,14 +52,14 @@ def _network_get_query(context, session=None):
                        read_deleted="no")
 
 def _instance_get_all_query(context, project_only=False,
-                            joins=None, use_slave=False):
+                            joins=None, use_subordinate=False):
     if joins is None:
         joins = ['info_cache', 'security_groups']
 
     query = model_query(context,
                         models.Instance,
                         project_only=project_only,
-                        use_slave=use_slave)
+                        use_subordinate=use_subordinate)
     # for join in joins:
     #     query = query.options(joinedload(join))
     return query
@@ -70,7 +70,7 @@ def _instance_pcidevs_get_multi(context, instance_uuids, session=None):
         filter(models.PciDevice.instance_uuid.in_(instance_uuids))
 
 def _instances_fill_metadata(context, instances,
-                             manual_joins=None, use_slave=False):
+                             manual_joins=None, use_subordinate=False):
     """Selectively fill instances with manually-joined metadata. Note that
     instance will be converted to a dict.
     :param context: security context
@@ -126,7 +126,7 @@ def _manual_join_columns(columns_to_join):
 
 def instance_get_all_by_filters(context, filters, sort_key, sort_dir,
                                 limit=None, marker=None, columns_to_join=None,
-                                use_slave=False):
+                                use_subordinate=False):
     """Return instances that match all filters.  Deleted instances
     will be returned by default, unless there's a filter that says
     otherwise.
@@ -168,10 +168,10 @@ def instance_get_all_by_filters(context, filters, sort_key, sort_dir,
 
     sort_fn = {'desc': desc, 'asc': asc}
 
-    # if CONF.database.slave_connection == '':
-    #     use_slave = False
+    # if CONF.database.subordinate_connection == '':
+    #     use_subordinate = False
 
-    session = get_session(use_slave=use_slave)
+    session = get_session(use_subordinate=use_subordinate)
 
     if columns_to_join is None:
         columns_to_join = ['info_cache', 'security_groups']

--- a/test/nova/methods/test_instance_get_all_by_host.py
+++ b/test/nova/methods/test_instance_get_all_by_host.py
@@ -31,7 +31,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()
@@ -48,14 +48,14 @@ def _network_get_query(context, session=None):
                        read_deleted="no")
 
 def _instance_get_all_query(context, project_only=False,
-                            joins=None, use_slave=False):
+                            joins=None, use_subordinate=False):
     if joins is None:
         joins = ['info_cache', 'security_groups']
 
     query = model_query(context,
                         models.Instance,
                         project_only=project_only,
-                        use_slave=use_slave)
+                        use_subordinate=use_subordinate)
     # for join in joins:
     #     query = query.options(joinedload(join))
     return query
@@ -66,7 +66,7 @@ def _instance_pcidevs_get_multi(context, instance_uuids, session=None):
         filter(models.PciDevice.instance_uuid.in_(instance_uuids))
 
 def _instances_fill_metadata(context, instances,
-                             manual_joins=None, use_slave=False):
+                             manual_joins=None, use_subordinate=False):
     """Selectively fill instances with manually-joined metadata. Note that
     instance will be converted to a dict.
     :param context: security context
@@ -114,9 +114,9 @@ def _instances_fill_metadata(context, instances,
 
 def instance_get_all_by_host(context, host,
                              columns_to_join=None,
-                             use_slave=False):
+                             use_subordinate=False):
     instances = _instance_get_all_query(context,
-                              use_slave=use_slave).filter_by(host=host).all()
+                              use_subordinate=use_subordinate).filter_by(host=host).all()
     return _instances_fill_metadata(context, instances, ["system_metadata"])
 
 

--- a/test/nova/methods/test_instance_get_from_db.py
+++ b/test/nova/methods/test_instance_get_from_db.py
@@ -22,7 +22,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_migration_get_in_progress_by_host_and_node.py
+++ b/test/nova/methods/test_migration_get_in_progress_by_host_and_node.py
@@ -30,7 +30,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_network_get_all_by_host.py
+++ b/test/nova/methods/test_network_get_all_by_host.py
@@ -30,7 +30,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_network_get_associated_fixed_ips.py
+++ b/test/nova/methods/test_network_get_associated_fixed_ips.py
@@ -29,7 +29,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_quota_get_all_by_project.py
+++ b/test/nova/methods/test_quota_get_all_by_project.py
@@ -31,7 +31,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()
@@ -48,14 +48,14 @@ def _network_get_query(context, session=None):
                        read_deleted="no")
 
 def _instance_get_all_query(context, project_only=False,
-                            joins=None, use_slave=False):
+                            joins=None, use_subordinate=False):
     if joins is None:
         joins = ['info_cache', 'security_groups']
 
     query = model_query(context,
                         models.Instance,
                         project_only=project_only,
-                        use_slave=use_slave)
+                        use_subordinate=use_subordinate)
     # for join in joins:
     #     query = query.options(joinedload(join))
     return query
@@ -66,7 +66,7 @@ def _instance_pcidevs_get_multi(context, instance_uuids, session=None):
         filter(models.PciDevice.instance_uuid.in_(instance_uuids))
 
 def _instances_fill_metadata(context, instances,
-                             manual_joins=None, use_slave=False):
+                             manual_joins=None, use_subordinate=False):
     """Selectively fill instances with manually-joined metadata. Note that
     instance will be converted to a dict.
     :param context: security context

--- a/test/nova/methods/test_quota_usage_get_all_by_project.py
+++ b/test/nova/methods/test_quota_usage_get_all_by_project.py
@@ -31,7 +31,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()
@@ -48,14 +48,14 @@ def _network_get_query(context, session=None):
                        read_deleted="no")
 
 def _instance_get_all_query(context, project_only=False,
-                            joins=None, use_slave=False):
+                            joins=None, use_subordinate=False):
     if joins is None:
         joins = ['info_cache', 'security_groups']
 
     query = model_query(context,
                         models.Instance,
                         project_only=project_only,
-                        use_slave=use_slave)
+                        use_subordinate=use_subordinate)
     # for join in joins:
     #     query = query.options(joinedload(join))
     return query
@@ -66,7 +66,7 @@ def _instance_pcidevs_get_multi(context, instance_uuids, session=None):
         filter(models.PciDevice.instance_uuid.in_(instance_uuids))
 
 def _instances_fill_metadata(context, instances,
-                             manual_joins=None, use_slave=False):
+                             manual_joins=None, use_subordinate=False):
     """Selectively fill instances with manually-joined metadata. Note that
     instance will be converted to a dict.
     :param context: security context

--- a/test/nova/methods/test_reservation_commit.py
+++ b/test/nova/methods/test_reservation_commit.py
@@ -35,7 +35,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_reservation_expire.py
+++ b/test/nova/methods/test_reservation_expire.py
@@ -35,7 +35,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()

--- a/test/nova/methods/test_service_get_all_by_compute_host.py
+++ b/test/nova/methods/test_service_get_all_by_compute_host.py
@@ -30,7 +30,7 @@ _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS = ['fault', 'numa_topology',
 INSTANCE_OPTIONAL_ATTRS = (_INSTANCE_OPTIONAL_JOINED_FIELDS +
                            _INSTANCE_OPTIONAL_NON_COLUMN_FIELDS)
 
-def get_session(use_slave=False, **kwargs):
+def get_session(use_subordinate=False, **kwargs):
     # return FakeSession()
     return RomeSession()
     # return OldRomeSession()


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.